### PR TITLE
Cirrus: Use ncdns master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
         cpu: 1
         memory: 1G
       install_script:
-        - dnf install -y make mingw32-nsis unzip wget
+        - dnf install -y git make mingw32-nsis unzip wget
       env:
         DISTRO: Fedora
         NCDNS_LOGGING: "1"
@@ -55,10 +55,16 @@ task:
     - tar -xaf qlib--windows_amd64.tar.gz
     - mv qlib--windows_amd64/bin/*.exe ./
     - rm -rf qlib--windows_amd64/
+    - curl -o ncdns--windows_amd64.tar.gz https://api.cirrus-ci.com/v1/artifact/github/namecoin/ncdns/Cross-Compile%20Go%20latest/binaries/dist/ncdns--windows_amd64.tar.gz
+    - tar -xaf ncdns--windows_amd64.tar.gz
+    - mv ncdns--windows_amd64/bin/*.exe ./
+    - rm -rf ncdns--windows_amd64/
     - cd ../../
   build_script:
+    # Tag detection from ncdns-repro
+    - NCDNS_TAG=$(git ls-remote --tags "https://github.com/namecoin/ncdns.git" | grep -v '\^{}' | awk '{print $2}' | awk -F"/" '{print $3}' | sort -V | tail --lines=1)
     # TODO: check for NSIS warnings
-    - make NCDNS_64BIT=1 NCDNS_PRODVER=v0.2
+    - make NCDNS_64BIT=1 NCDNS_PRODVER=$NCDNS_TAG
     - mv build64/bin/ncdns-*-win64-install.exe ./ncdns--win64-install.exe
   upload_script:
     - curl -s -X POST --data-binary @ncdns--win64-install.exe http://$CIRRUS_HTTP_CACHE_HOST/cross_compile_bin_$DISTRO

--- a/Makefile
+++ b/Makefile
@@ -70,21 +70,6 @@ OUTFN := $(BUILD)/bin/ncdns-$(NCDNS_PRODVER)-$(NCARCH)-install.exe
 all: $(OUTFN)
 
 
-### NCDNS
-##############################################################################
-NCDNS_ARCFN=ncdns-$(NCDNS_PRODVER)-windows_$(GOARCH).tar.gz
-
-$(ARTIFACTS)/$(NCDNS_ARCFN):
-	mkdir -p "$(ARTIFACTS)"
-	wget -O "$@" "https://api.cirrus-ci.com/v1/artifact/github/namecoin/ncdns/Cross-Compile Go latest/binaries/dist/$(NCDNS_ARCFN)?branch=$(NCDNS_PRODVER)"
-
-EXES=ncdns ncdumpzone generate_nmc_cert ncdt tlsrestrict_chromium_tool
-EXES_A=$(foreach k,$(EXES),$(ARTIFACTS)/$(k).exe)
-
-$(ARTIFACTS)/ncdns.exe: $(ARTIFACTS)/$(NCDNS_ARCFN)
-	(cd "$(ARTIFACTS)"; tar zxvf "$(NCDNS_ARCFN)"; mv ncdns-$(NCDNS_PRODVER)-windows_$(GOARCH)/bin/* ./; rm -rf ncdns-$(NCDNS_PRODVER)-windows_$(GOARCH);)
-
-
 ### DNSSEC-KEYGEN
 ##############################################################################
 # When bumping the BIND version, make sure to test whether its Visual C++
@@ -131,7 +116,7 @@ $(ARTIFACTS)/$(NAMECOIN_FN):
 
 ### INSTALLER
 ##############################################################################
-$(OUTFN): ncdns.nsi $(NEUTRAL_ARTIFACTS)/ncdns.conf $(EXES_A) $(KGFILES_A) $(ARTIFACTS)/$(DNSSEC_TRIGGER_FN) $(ARTIFACTS)/$(NAMECOIN_FN) $(ARTIFACTS)/q.exe
+$(OUTFN): ncdns.nsi $(NEUTRAL_ARTIFACTS)/ncdns.conf $(KGFILES_A) $(ARTIFACTS)/$(DNSSEC_TRIGGER_FN) $(ARTIFACTS)/$(NAMECOIN_FN) $(ARTIFACTS)/q.exe
 	@mkdir -p "$(BUILD)/bin"
 	$(MAKENSIS) $(NSISFLAGS) -DPOSIX_BUILD=1 -DNCDNS_PRODVER=$(NCDNS_PRODVER_W) \
 		$(_NCDNS_64BIT) $(_NO_NAMECOIN_CORE) $(_NO_DNSSEC_TRIGGER) $(_NCDNS_LOGGING) \


### PR DESCRIPTION
Fixes a Cirrus failure due to expired build artifacts.